### PR TITLE
use __construct

### DIFF
--- a/Net/IMAP.php
+++ b/Net/IMAP.php
@@ -43,12 +43,12 @@ class Net_IMAP extends Net_IMAPProtocol
      * @param bool   $enableSTARTTLS Enable STARTTLS support
      * @param string $encoding       Character encoding
      */
-    function Net_IMAP($host = 'localhost',
+    function __construct($host = 'localhost',
                       $port = 143, 
                       $enableSTARTTLS = true,
                       $encoding = 'ISO-8859-1')
     {
-        $this->Net_IMAPProtocol();
+        parent::__construct();
         $ret             = $this->connect($host, $port, $enableSTARTTLS);
         $this->_encoding = $encoding;
     }

--- a/Net/IMAPProtocol.php
+++ b/Net/IMAPProtocol.php
@@ -165,7 +165,7 @@ class Net_IMAPProtocol
      *
      * @since  1.0
      */
-    function Net_IMAPProtocol()
+    function __construct()
     {
         $this->_socket = new Net_Socket();
 


### PR DESCRIPTION
Using the __construct feature cause named-function is deprecated.